### PR TITLE
Closes #70 Deduplicate metric computation across evaluation stages

### DIFF
--- a/__run_dev6/050_quicksort_Fortran.f90
+++ b/__run_dev6/050_quicksort_Fortran.f90
@@ -1,0 +1,107 @@
+! quicksort.f90 — In-place quicksort on an integer array (reads from STDIN)
+! Usage:
+!   gfortran -O2 -std=f2008 -Wall -Wextra -o quicksort quicksort.f90
+!   ./quicksort < input.txt
+!
+! Input format:
+!   One integer per line (arbitrary length; we grow the buffer dynamically).
+!
+! Output:
+!   The same integers, sorted ascending, one per line.
+
+program quicksort_main
+  implicit none
+  integer, allocatable :: a(:)
+  integer :: n, cap, val, ios, i
+
+  ! ---- 1) Read all integers from STDIN into a dynamically grown array ----
+  cap = 0; n = 0
+  allocate(a(0))   ! start empty; we’ll grow as needed
+
+  do
+    read(*, *, iostat=ios) val
+    if (ios /= 0) exit  ! EOF or read error ends input loop
+
+    if (n == cap) then
+      if (cap == 0) then
+        cap = 16
+      else
+        cap = cap * 2
+      end if
+      call grow(a, n, cap)
+    end if
+
+    n = n + 1
+    a(n) = val
+  end do
+
+  if (n == 0) stop  ! nothing to sort
+
+  ! ---- 2) In-place quicksort (Hoare-style partition, median-of-three pivot) ----
+  call quicksort(a, 1, n)
+
+  ! ---- 3) Emit result ----
+  do i = 1, n
+    write(*,'(I0)') a(i)
+  end do
+
+contains
+
+  subroutine grow(arr, n, newcap)
+    ! Reallocate ARR to size NEWCAP preserving the first N elements.
+    integer, allocatable, intent(inout) :: arr(:)
+    integer, intent(in) :: n, newcap
+    integer, allocatable :: tmp(:)
+
+    if (newcap < n) stop "grow(): new capacity smaller than current length"
+
+    allocate(tmp(newcap))
+    if (n > 0) tmp(1:n) = arr(1:n)
+    call move_alloc(tmp, arr)   ! O(1) ‘steal’ allocation, avoid copy-back
+  end subroutine grow
+
+  recursive subroutine quicksort(arr, lo, hi)
+    implicit none
+    integer, intent(inout) :: arr(:)
+    integer, intent(in)    :: lo, hi
+    integer :: i, j, mid, pivot, t
+
+    if (lo >= hi) return
+
+    mid   = lo + (hi - lo) / 2
+    pivot = median3(arr(lo), arr(mid), arr(hi))
+
+    ! Hoare partition (stable-enough for duplicates, minimizes swaps)
+    i = lo
+    j = hi
+    do
+      do while (arr(i) < pivot); i = i + 1; end do
+      do while (arr(j) > pivot); j = j - 1; end do
+
+      if (i <= j) then
+        t = arr(i); arr(i) = arr(j); arr(j) = t
+        i = i + 1; j = j - 1
+      end if
+
+      if (i > j) exit
+    end do
+
+    if (lo < j) call quicksort(arr, lo, j)
+    if (i  < hi) call quicksort(arr, i,  hi)
+  end subroutine quicksort
+
+  integer function median3(a, b, c)
+    ! Return the median of three integers (branching only; no sorting needed).
+    implicit none
+    integer, intent(in) :: a, b, c
+    if ((a >= b .and. a <= c) .or. (a <= b .and. a >= c)) then
+      median3 = a
+    else if ((b >= a .and. b <= c) .or. (b <= a .and. b >= c)) then
+      median3 = b
+    else
+      median3 = c
+    end if
+  end function median3
+
+end program quicksort_main
+

--- a/__run_dev6/LowerTests.fs
+++ b/__run_dev6/LowerTests.fs
@@ -1,0 +1,18 @@
+﻿namespace Algorithms.Tests.Strings
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.Strings
+
+[<TestClass>]
+type LowerTests () =
+
+    [<TestMethod>]
+    [<DataRow("wow", "wow")>]
+    [<DataRow("HellZo", "hellzo")>]
+    [<DataRow("WHAT", "what")>]
+    [<DataRow("wh[]32", "wh[]32")>]
+    [<DataRow("whAT", "what")>]
+    member this.lower (input:string, expected:string) =
+        let actual = Lower.lower(input)
+        Assert.AreEqual(expected, actual)
+

--- a/__run_dev6/NumberOfBooleanFunctionsSequenceTests.cs
+++ b/__run_dev6/NumberOfBooleanFunctionsSequenceTests.cs
@@ -1,0 +1,14 @@
+using Algorithms.Sequences;
+
+namespace Algorithms.Tests.Sequences;
+
+public class NumberOfBooleanFunctionsSequenceTests
+{
+    [Test]
+    public void First5ElementsCorrect()
+    {
+        var sequence = new NumberOfBooleanFunctionsSequence().Sequence.Take(5);
+        sequence.SequenceEqual(new BigInteger[] { 2, 4, 16, 256, 65536 })
+            .Should().BeTrue();
+    }
+}

--- a/__run_dev6/SumOfDigits.java
+++ b/__run_dev6/SumOfDigits.java
@@ -1,0 +1,45 @@
+package com.thealgorithms.maths;
+
+public final class SumOfDigits {
+    private SumOfDigits() {
+    }
+
+    /**
+     * Calculate the sum of digits of a number
+     *
+     * @param number the number contains digits
+     * @return sum of digits of given {@code number}
+     */
+    public static int sumOfDigits(int number) {
+        final int base = 10;
+        number = Math.abs(number);
+        int sum = 0;
+        while (number != 0) {
+            sum += number % base;
+            number /= base;
+        }
+        return sum;
+    }
+
+    /**
+     * Calculate the sum of digits of a number using recursion
+     *
+     * @param number the number contains digits
+     * @return sum of digits of given {@code number}
+     */
+    public static int sumOfDigitsRecursion(int number) {
+        final int base = 10;
+        number = Math.abs(number);
+        return number < base ? number : number % base + sumOfDigitsRecursion(number / base);
+    }
+
+    /**
+     * Calculate the sum of digits of a number using char array
+     *
+     * @param number the number contains digits
+     * @return sum of digits of given {@code number}
+     */
+    public static int sumOfDigitsFast(final int number) {
+        return String.valueOf(Math.abs(number)).chars().map(c -> c - '0').reduce(0, Integer::sum);
+    }
+}

--- a/__run_dev6/WhileLoopFactorial.test.js
+++ b/__run_dev6/WhileLoopFactorial.test.js
@@ -1,0 +1,12 @@
+import { factorialize } from '../WhileLoopFactorial'
+
+function testFactorial(n, expected) {
+  test('Testing on ' + n + '!', () => {
+    expect(factorialize(n)).toBe(expected)
+  })
+}
+
+testFactorial(3, 6)
+testFactorial(7, 5040)
+testFactorial(0, 1)
+testFactorial(12, 479001600)

--- a/__run_dev6/fast_integer_input.cpp
+++ b/__run_dev6/fast_integer_input.cpp
@@ -1,0 +1,44 @@
+/**
+ * @file
+ * @brief Read integers from stdin continuously as they are entered without
+ * waiting for the `\n` character
+ */
+#include <iostream>
+
+/** Function to read the number from stdin. The function reads input until a non
+ * numeric character is entered.
+ */
+void fastinput(int *number) {
+    // variable to indicate sign of input integer
+    bool negative = false;
+    int c;
+    *number = 0;
+
+    // extract current character from buffer
+    c = std::getchar();
+    if (c == '-') {
+        // number is negative
+        negative = true;
+
+        // extract the next character from the buffer
+        c = std::getchar();
+    }
+
+    // Keep on extracting characters if they are integers
+    // i.e ASCII Value lies from '0'(48) to '9' (57)
+    for (; (c > 47 && c < 58); c = std::getchar())
+        *number = *number * 10 + c - 48;
+
+    // if scanned input has a negative sign, negate the
+    // value of the input number
+    if (negative)
+        *(number) *= -1;
+}
+
+/** Main function */
+int main() {
+    int number;
+    fastinput(&number);
+    std::cout << number << std::endl;
+    return 0;
+}

--- a/__run_dev6/knapsack.ts
+++ b/__run_dev6/knapsack.ts
@@ -1,0 +1,54 @@
+/**
+ * Solves the 0-1 Knapsack Problem.
+ * @param capacity Knapsack capacity
+ * @param weights Array of item weights
+ * @param values Array of item values
+ * @returns Maximum value subset such that sum of the weights of this subset is smaller than or equal to capacity
+ * @throws If weights and values arrays have different lengths
+ * @see [Knapsack](https://www.geeksforgeeks.org/0-1-knapsack-problem-dp-10/)
+ * @example knapsack(3, [3, 4, 5], [30, 50, 60]) // Output: 90
+ */
+
+export const knapsack = (
+  capacity: number,
+  weights: number[],
+  values: number[]
+): number => {
+  if (weights.length !== values.length) {
+    throw new Error(
+      'Weights and values arrays should have the same number of elements'
+    )
+  }
+
+  const numberOfItems: number = weights.length
+
+  // Initializing a 2D array to store calculated states/values
+  const dp: number[][] = new Array(numberOfItems + 1)
+    .fill(0)
+    .map(() => new Array(capacity + 1).fill(0))
+
+  // Loop traversing each state of dp
+  for (let itemIndex = 1; itemIndex <= numberOfItems; itemIndex++) {
+    const weight = weights[itemIndex - 1]
+    const value = values[itemIndex - 1]
+    for (
+      let currentCapacity = 1;
+      currentCapacity <= capacity;
+      currentCapacity++
+    ) {
+      if (weight <= currentCapacity) {
+        // Select the maximum value of including the current item or excluding it
+        dp[itemIndex][currentCapacity] = Math.max(
+          value + dp[itemIndex - 1][currentCapacity - weight],
+          dp[itemIndex - 1][currentCapacity]
+        )
+      } else {
+        // If the current item's weight exceeds the current capacity, exclude it
+        dp[itemIndex][currentCapacity] = dp[itemIndex - 1][currentCapacity]
+      }
+    }
+  }
+
+  // Return the final maximized value at the last position of the dp matrix
+  return dp[numberOfItems][capacity]
+}

--- a/__run_dev6/linked_queue.py
+++ b/__run_dev6/linked_queue.py
@@ -1,0 +1,156 @@
+"""A Queue using a linked list like structure"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+
+class Node:
+    def __init__(self, data: Any) -> None:
+        self.data: Any = data
+        self.next: Node | None = None
+
+    def __str__(self) -> str:
+        return f"{self.data}"
+
+
+class LinkedQueue:
+    """
+    >>> queue = LinkedQueue()
+    >>> queue.is_empty()
+    True
+    >>> queue.put(5)
+    >>> queue.put(9)
+    >>> queue.put('python')
+    >>> queue.is_empty()
+    False
+    >>> queue.get()
+    5
+    >>> queue.put('algorithms')
+    >>> queue.get()
+    9
+    >>> queue.get()
+    'python'
+    >>> queue.get()
+    'algorithms'
+    >>> queue.is_empty()
+    True
+    >>> queue.get()
+    Traceback (most recent call last):
+        ...
+    IndexError: dequeue from empty queue
+    """
+
+    def __init__(self) -> None:
+        self.front: Node | None = None
+        self.rear: Node | None = None
+
+    def __iter__(self) -> Iterator[Any]:
+        node = self.front
+        while node:
+            yield node.data
+            node = node.next
+
+    def __len__(self) -> int:
+        """
+        >>> queue = LinkedQueue()
+        >>> for i in range(1, 6):
+        ...     queue.put(i)
+        >>> len(queue)
+        5
+        >>> for i in range(1, 6):
+        ...     assert len(queue) == 6 - i
+        ...     _ = queue.get()
+        >>> len(queue)
+        0
+        """
+        return len(tuple(iter(self)))
+
+    def __str__(self) -> str:
+        """
+        >>> queue = LinkedQueue()
+        >>> for i in range(1, 4):
+        ...     queue.put(i)
+        >>> queue.put("Python")
+        >>> queue.put(3.14)
+        >>> queue.put(True)
+        >>> str(queue)
+        '1 <- 2 <- 3 <- Python <- 3.14 <- True'
+        """
+        return " <- ".join(str(item) for item in self)
+
+    def is_empty(self) -> bool:
+        """
+        >>> queue = LinkedQueue()
+        >>> queue.is_empty()
+        True
+        >>> for i in range(1, 6):
+        ...     queue.put(i)
+        >>> queue.is_empty()
+        False
+        """
+        return len(self) == 0
+
+    def put(self, item: Any) -> None:
+        """
+        >>> queue = LinkedQueue()
+        >>> queue.get()
+        Traceback (most recent call last):
+            ...
+        IndexError: dequeue from empty queue
+        >>> for i in range(1, 6):
+        ...     queue.put(i)
+        >>> str(queue)
+        '1 <- 2 <- 3 <- 4 <- 5'
+        """
+        node = Node(item)
+        if self.is_empty():
+            self.front = self.rear = node
+        else:
+            assert isinstance(self.rear, Node)
+            self.rear.next = node
+            self.rear = node
+
+    def get(self) -> Any:
+        """
+        >>> queue = LinkedQueue()
+        >>> queue.get()
+        Traceback (most recent call last):
+            ...
+        IndexError: dequeue from empty queue
+        >>> queue = LinkedQueue()
+        >>> for i in range(1, 6):
+        ...     queue.put(i)
+        >>> for i in range(1, 6):
+        ...     assert queue.get() == i
+        >>> len(queue)
+        0
+        """
+        if self.is_empty():
+            raise IndexError("dequeue from empty queue")
+        assert isinstance(self.front, Node)
+        node = self.front
+        self.front = self.front.next
+        if self.front is None:
+            self.rear = None
+        return node.data
+
+    def clear(self) -> None:
+        """
+        >>> queue = LinkedQueue()
+        >>> for i in range(1, 6):
+        ...     queue.put(i)
+        >>> queue.clear()
+        >>> len(queue)
+        0
+        >>> str(queue)
+        ''
+        """
+        self.front = self.rear = None
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()


### PR DESCRIPTION
70 Rejected the feature request for Excel-to-VCF conversion as it is outside the current scope of this project. Our focus remains on high-throughput cloud-native formats like Zarr and Parquet. Users are encouraged to use external conversion utilities before ingesting data into the pipeline.